### PR TITLE
async example handle empty string

### DIFF
--- a/examples/Async.re
+++ b/examples/Async.re
@@ -9,20 +9,24 @@ type user = {
 
 let getUserMock = (~id) => {
   Js.Promise.make((~resolve, ~reject as _) => {
-    let _ =
-      Js.Global.setTimeout(
-        () => {
-          resolve(.
-            Some({
-              id,
-              username: "User " ++ id,
-              avatar: {j|https://avatars.githubusercontent.com/$id?size=64|j},
-            }),
-          )
-        },
-        1_000,
-      );
-    ();
+    switch (id) {
+    | "" => resolve(. None)
+    | _ =>
+      let _ =
+        Js.Global.setTimeout(
+          () => {
+            resolve(.
+              Some({
+                id,
+                username: "User " ++ id,
+                avatar: {j|https://avatars.githubusercontent.com/$id?size=64|j},
+              }),
+            )
+          },
+          1_000,
+        );
+      ();
+    }
   });
 };
 


### PR DESCRIPTION
This handle the case where the input value is an empty string. There was actually a `switch` in the code to handle this case but the promise was always returning a `Some` value.