### PR TITLE
RFC: functional state setter for selectors

### DIFF
--- a/src/Recoil.rei
+++ b/src/Recoil.rei
@@ -227,11 +227,8 @@ external useRecoilState:
   readWrite('value) => ('value, ('value => 'value) => unit) =
   "useRecoilState";
 
-type value('value) = 'value;
-
 [@bs.module "recoil"]
-external useRecoilValue: t('value, 'mode) => value('value) =
-  "useRecoilValue";
+external useRecoilValue: t('value, 'mode) => 'value = "useRecoilValue";
 
 [@bs.module "recoil"]
 external useRecoilValueLoadable: t('value, 'mode) => Loadable.t('value) =

--- a/src/Recoil.rei
+++ b/src/Recoil.rei
@@ -61,7 +61,7 @@ type getter = {get: 'value 'mode. t('value, 'mode) => 'value};
 
 type getterAndSetter = {
   get: 'value 'mode. t('value, 'mode) => 'value,
-  set: 'value. (readWrite('value), 'value) => unit,
+  set: 'value. (readWrite('value), 'value => 'value) => unit,
   reset: 'value. readWrite('value) => unit,
 };
 

--- a/src/Recoil__React.re
+++ b/src/Recoil__React.re
@@ -16,10 +16,8 @@ external useRecoilState:
   Recoil__Value.readWrite('value) => ('value, ('value => 'value) => unit) =
   "useRecoilState";
 
-type value('a) = 'a;
-
 [@bs.module "recoil"]
-external useRecoilValue: Recoil__Value.t('value, 'mode) => value('value) =
+external useRecoilValue: Recoil__Value.t('value, 'mode) => 'value =
   "useRecoilValue";
 
 type set('a) = ('a => 'a) => unit;

--- a/src/Recoil__Selector.re
+++ b/src/Recoil__Selector.re
@@ -2,7 +2,7 @@ type getter = {get: 'value 'mode. Recoil__Value.t('value, 'mode) => 'value};
 
 type getterAndSetter = {
   get: 'value 'mode. Recoil__Value.t('value, 'mode) => 'value,
-  set: 'value. (Recoil__Value.readWrite('value), 'value) => unit,
+  set: 'value. (Recoil__Value.readWrite('value), 'value => 'value) => unit,
   reset: 'value. Recoil__Value.readWrite('value) => unit,
 };
 

--- a/test/Recoil__test.re
+++ b/test/Recoil__test.re
@@ -233,7 +233,9 @@ let usernameSize =
       username->Js.String.length;
     },
     set: ({set, get}, newValue) => {
-      set(username, get(username)->Js.String.slice(~from=0, ~to_=newValue));
+      set(username, _ =>
+        get(username)->Js.String.slice(~from=0, ~to_=newValue)
+      );
     },
   });
 let usernameSizeReadOnly =


### PR DESCRIPTION
For read-write selectors, change the setter to a function of the old value, to match what's done elsewhere in `useRecoilCallback`,  `useRecoilState` and `useSetRecoilState`.